### PR TITLE
fix: not re-render react component when pass object props to react

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,9 +65,10 @@ function angularizeDirective(Component, directiveName, angularApp, bindings) {
 						keys.push(bindingKey);
 					}
 				}
-
-				scope.$watchGroup(keys, () => {
-					ReactDOM.render(React.createElement(Component, scope), element[0]);
+				keys.forEach(prop => {
+					scope.$watch(prop, () => {
+						ReactDOM.render(React.createElement(Component, scope), element[0])
+					}, true)
 				});
 			}
 		}


### PR DESCRIPTION
$watchGroups method won't deep compare object. so when we pass an object from $scope to react. change of this object won't re-render react component. we need watch with deep equal.